### PR TITLE
Experimental fuzzing support 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ spin_sleep = "0.3.7"
 futures-timer = "0.3.0"
 futures-preview = "0.3.0-alpha.17"
 crossbeam-channel = "0.3.9"
+byte-mutator = {path = "/home/ragona/src/byte-mutator"}
 
 [dev-dependencies]
 criterion = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,17 @@ ctrlc = "3.1.3"
 clap = "2.33.0"
 fern = "0.5.8"
 rand = "0.7.0"
+toml = "0.5.5"
 chrono = "0.4.7"
+serde = "1.0.102"
 num_cpus = "1.10.1"
 humantime = "1.2.0"
 async-std = "0.99.4"
 spin_sleep = "0.3.7"
 futures-timer = "0.3.0"
-futures-preview = "0.3.0-alpha.17"
+serde_derive = "1.0.102"
 crossbeam-channel = "0.3.9"
+futures-preview = "0.3.0-alpha.17"
 byte-mutator = {path = "/home/ragona/src/byte-mutator"}
 
 [dev-dependencies]

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,16 +4,10 @@
 //! to copy, as it is passed to each `connection()` call.
 //!
 
-use std::fs::{self, File};
-use std::io::Read;
-use std::net::{IpAddr, SocketAddr};
-use std::path::Path;
+use std::net::SocketAddr;
 use std::time::Duration;
 
-use byte_mutator::fuzz_config::FuzzConfig;
-use futures::io::Error;
 use serde_derive::Deserialize;
-use toml;
 
 /// Settings for the load test
 ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,21 +4,27 @@
 //! to copy, as it is passed to each `connection()` call.
 //!
 
-extern crate proc_macro;
-
-use std::net::SocketAddr;
+use std::fs::{self, File};
+use std::io::Read;
+use std::net::{IpAddr, SocketAddr};
+use std::path::Path;
 use std::time::Duration;
+
+use futures::io::Error;
+use serde_derive::Deserialize;
+use toml;
 
 /// Settings for the load test
 ///
 /// todo: Make write/read optional. (Enum?)
 ///
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Deserialize)]
 pub struct Config {
     /// Socket address (ip and port) of the host we'll be calling
     pub target: SocketAddr,
     /// Connections is the a key knob to turn when tuning a performance test. Honestly
-    /// 'connections' isn't the best name; it implies a certain persistance that
+    /// 'connections' isn't the best name; it implies a certain persistance that isn't true.
+    /// todo: Rename to workers?
     pub connections: u32,
     /// Optional rate-limiting. Precisely timing high rates is unreliable; if you're
     /// seeing slower than expected performance try running with no rate limit at all.
@@ -56,6 +62,21 @@ impl Config {
             threads: None,
             read_timeout: None,
             connect_timeout: None,
+        }
+    }
+
+    // todo: Actually implement this
+    pub fn from_file(path: &str) -> std::io::Result<Config> {
+        unimplemented!();
+        match fs::read_to_string(path) {
+            Ok(s) => match toml::from_str(&s) {
+                Ok(c) => Ok(c),
+                Err(e) => Err(Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "Failed to parse config",
+                )),
+            },
+            Err(e) => Err(e),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::path::Path;
 use std::time::Duration;
 
+use byte_mutator::fuzz_config::FuzzConfig;
 use futures::io::Error;
 use serde_derive::Deserialize;
 use toml;
@@ -18,7 +19,7 @@ use toml;
 ///
 /// todo: Make write/read optional. (Enum?)
 ///
-#[derive(Debug, Copy, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Config {
     /// Socket address (ip and port) of the host we'll be calling
     pub target: SocketAddr,
@@ -45,8 +46,10 @@ pub struct Config {
     pub read_timeout: Option<u32>,
     /// Absolute number of requests to be made. Should split evenly across threads.
     pub limit: Option<u32>,
-    /// Repeats the outgoing message
+    /// Repeats the outgoing message multiple times per connection.
     pub repeat: u32,
+    /// Fuzzing config toml file
+    pub fuzz_path: Option<String>,
 }
 
 impl Config {
@@ -62,6 +65,7 @@ impl Config {
             threads: None,
             read_timeout: None,
             connect_timeout: None,
+            fuzz_path: None,
         }
     }
 
@@ -171,6 +175,11 @@ impl ConfigBuilder {
 
     pub fn repeat(mut self, repeat: u32) -> ConfigBuilder {
         self.config.repeat = repeat;
+        self
+    }
+
+    pub fn fuzz_path(mut self, path: String) -> ConfigBuilder {
+        self.config.fuzz_path = Some(path);
         self
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,21 +69,6 @@ impl Config {
         }
     }
 
-    // todo: Actually implement this
-    pub fn from_file(path: &str) -> std::io::Result<Config> {
-        unimplemented!();
-        match fs::read_to_string(path) {
-            Ok(s) => match toml::from_str(&s) {
-                Ok(c) => Ok(c),
-                Err(e) => Err(Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    "Failed to parse config",
-                )),
-            },
-            Err(e) => Err(e),
-        }
-    }
-
     /// Number of user-defined threads, or all the threads on the host.
     pub fn num_threads(&self) -> u32 {
         match self.threads {
@@ -178,8 +163,8 @@ impl ConfigBuilder {
         self
     }
 
-    pub fn fuzz_path(mut self, path: String) -> ConfigBuilder {
-        self.config.fuzz_path = Some(path);
+    pub fn fuzz_path(mut self, path: Option<String>) -> ConfigBuilder {
+        self.config.fuzz_path = path;
         self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,10 @@
 //!
 //! ```no_run
 //! # use std::time::Duration;
-//! # use clobber::{tcp, Message, Config, ConfigBuilder};
+//! # use clobber::{tcp, Config, ConfigBuilder};
 //!
 //! let addr = "127.0.0.1:8000".parse().unwrap();
-//! let message = Message::new(b"GET / HTTP/1.1\r\nHost: localhost:8000\r\nConnection: close\r\n\r\n");
+//! let message = b"GET / HTTP/1.1\r\nHost: localhost:8000\r\nConnection: close\r\n\r\n".to_vec();
 //! let config = ConfigBuilder::new(addr)
 //!     .connections(10)
 //!     .build();
@@ -31,26 +31,9 @@ pub mod util;
 pub use config::{Config, ConfigBuilder};
 pub use stats::Stats;
 
-use byte_mutator::undo_buffer::UndoBuffer;
+use byte_mutator::ByteMutator;
 use fern;
 use log::LevelFilter;
-
-/// Message payload
-///
-/// todo: Long-term goal; provide APIs for each connection to mutate its message.
-///
-#[derive(Debug, Clone)]
-pub struct Message {
-    pub body: UndoBuffer,
-}
-
-impl Message {
-    pub fn new(bytes: &[u8]) -> Message {
-        Message {
-            body: UndoBuffer::new(bytes),
-        }
-    }
-}
 
 pub fn setup_logger(log_level: LevelFilter) -> Result<(), Box<dyn std::error::Error>> {
     fern::Dispatch::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,8 @@
 //! # use std::time::Duration;
 //! # use clobber::{tcp, Config, ConfigBuilder};
 //!
-//! let addr = "127.0.0.1:8000".parse().unwrap();
 //! let message = b"GET / HTTP/1.1\r\nHost: localhost:8000\r\nConnection: close\r\n\r\n".to_vec();
+//! let addr = "127.0.0.1:8000".parse().unwrap();
 //! let config = ConfigBuilder::new(addr)
 //!     .connections(10)
 //!     .build();
@@ -31,7 +31,6 @@ pub mod util;
 pub use config::{Config, ConfigBuilder};
 pub use stats::Stats;
 
-use byte_mutator::ByteMutator;
 use fern;
 use log::LevelFilter;
 
@@ -52,9 +51,4 @@ pub fn setup_logger(log_level: LevelFilter) -> Result<(), Box<dyn std::error::Er
         .apply()?;
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use clap::{App, Arg, ArgMatches};
 use humantime;
 
 use clobber::util::optional_stdin;
-use clobber::{setup_logger, tcp, Config, ConfigBuilder, Message};
+use clobber::{setup_logger, tcp, Config, ConfigBuilder};
 
 fn main() {
     let cli = cli();
@@ -31,7 +31,7 @@ fn main() {
         None => unimplemented!("no request body"), // todo: Load from file
     };
 
-    tcp::clobber(settings, Message::new(&bytes)).expect("Failed to clobber :(");
+    tcp::clobber(settings, bytes).expect("Failed to clobber :(");
 }
 
 fn cli() -> App<'static, 'static> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,13 @@ fn cli() -> App<'static, 'static> {
                 .help("Repeats the outgoing message")
                 .takes_value(true),
         )
+        .arg(
+            Arg::with_name("fuzz")
+                .short("f")
+                .long("fuzz")
+                .help("Path to a fuzzing config .toml file")
+                .takes_value(true),
+        )
 }
 
 fn settings_from_argmatches(matches: &ArgMatches) -> Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,6 +144,11 @@ fn settings_from_argmatches(matches: &ArgMatches) -> Config {
         .parse::<u32>()
         .expect("Failed to parse connections");
 
+    let fuzz_path = match matches.value_of("fuzz") {
+        None => None,
+        Some(s) => Some(String::from(s)),
+    };
+
     let connect_timeout = match matches.value_of("connect-timeout") {
         Some(timeout) => Some(timeout.parse().expect("Failed to parse connect_timeout")),
         None => None,
@@ -180,6 +185,7 @@ fn settings_from_argmatches(matches: &ArgMatches) -> Config {
         .repeat(repeat)
         .threads(threads)
         .duration(duration)
+        .fuzz_path(fuzz_path)
         .connections(connections)
         .read_timeout(read_timeout)
         .connect_timeout(connect_timeout)

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
         None => unimplemented!("no request body"), // todo: Load from file
     };
 
-    tcp::clobber(settings, Message::new(bytes)).expect("Failed to clobber :(");
+    tcp::clobber(settings, Message::new(&bytes)).expect("Failed to clobber :(");
 }
 
 fn cli() -> App<'static, 'static> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,7 +11,6 @@ use async_std::task;
 async fn process(stream: TcpStream) -> io::Result<()> {
     let (reader, writer) = &mut (&stream, &stream);
     let mut buf = [0_u8; 1024];
-
     let bytes_read = reader.read(&mut buf).await?;
     writer.write(&buf[0..bytes_read]).await?;
     Ok(())

--- a/src/server.rs
+++ b/src/server.rs
@@ -14,7 +14,6 @@ async fn process(stream: TcpStream) -> io::Result<()> {
 
     let bytes_read = reader.read(&mut buf).await?;
     writer.write(&buf[0..bytes_read]).await?;
-
     Ok(())
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,7 +3,7 @@
 use std::thread;
 use std::net::SocketAddr;
 
-use async_std::io::{self, Read};
+use async_std::io;
 use async_std::net::{TcpListener, TcpStream};
 use async_std::prelude::*;
 use async_std::task;

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -68,7 +68,6 @@ use futures::io::Error;
 ///
 pub fn clobber(config: Config, message: Vec<u8>) -> std::io::Result<()> {
     info!("Starting: {:#?}", config);
-
     let mut threads = Vec::with_capacity(config.num_threads() as usize);
 
     // configure fuzzing if a file has been provided in the config
@@ -110,12 +109,10 @@ pub fn clobber(config: Config, message: Vec<u8>) -> std::io::Result<()> {
                             .await
                             .expect("Failed to run connection");
                     }).unwrap();
-
             }
             pool.run();
         });
         threads.push(thread);
-
     }
     for handle in threads {
         handle.join().unwrap();
@@ -281,7 +278,6 @@ mod tests {
             Ok::<_, io::Error>(bytes_written)
         });
 
-        dbg!(&result);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), want);
     }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -85,9 +85,6 @@ pub fn clobber(config: Config, message: Vec<u8>) -> std::io::Result<()> {
     };
 
     for _ in 0..config.num_threads() {
-        // spread out threads within a second to stagger request volume (not sure this helps?)
-        std::thread::sleep(Duration::from_secs(1) / config.num_threads());
-
         // per-thread clones
         let message = message.clone();
         let config = config.clone();
@@ -173,7 +170,7 @@ async fn connection(mut message: ByteMutator, config: Config) -> io::Result<()> 
             }
             None => false,
         }
-        };
+    };
 
     // This is the guts of the application; the tight loop that executes requests
     let mut read_buffer = [0u8; 1024]; // todo variable size? :(
@@ -187,9 +184,10 @@ async fn connection(mut message: ByteMutator, config: Config) -> io::Result<()> 
                     read(&mut stream, &mut read_buffer).await.ok();
                 }
             }
+
             // todo: analysis
 
-            // advance mutator state
+            // advance mutator state (no-op with no fuzzer config)
             message.next();
         }
 

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -36,9 +36,9 @@
 //!
 
 use std::net::SocketAddr;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
-use async_std::io::{self, Read};
+use async_std::io::{self};
 use async_std::net::{TcpStream};
 use async_std::prelude::*;
 
@@ -53,7 +53,6 @@ use log::{debug, error, info, warn};
 use crate::{Config};
 use byte_mutator::ByteMutator;
 use byte_mutator::fuzz_config::FuzzConfig;
-use futures::io::Error;
 
 /// The overall test runner
 ///

--- a/tests/fuzz_config.toml
+++ b/tests/fuzz_config.toml
@@ -1,0 +1,10 @@
+[[stages]]
+    # todo: Reconsider exposing the state like this
+    cur_iterations = 0
+    max_iterations = 100
+
+    # a list of mutations to perform on this stage
+    [[stages.mutations]]
+    mutation = {"BitFlipper" = {width = 1}}
+    range = [0, 10]     
+    width = 1   

--- a/tests/fuzz_config.toml
+++ b/tests/fuzz_config.toml
@@ -1,10 +1,6 @@
 [[stages]]
-    # todo: Reconsider exposing the state like this
-    cur_iterations = 0
-    max_iterations = 100
-
+    count = 0
+    iterations = "Unlimited"
     # a list of mutations to perform on this stage
     [[stages.mutations]]
     mutation = {"BitFlipper" = {width = 1}}
-    range = [0, 10]     
-    width = 1   

--- a/tests/test_tcp_clobber.rs
+++ b/tests/test_tcp_clobber.rs
@@ -57,3 +57,18 @@ fn rateless_with_duration() -> std::io::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn with_fuzz_config() -> std::io::Result<()> {
+    let addr = echo_server()?;
+    let config = ConfigBuilder::new(addr)
+        .connections(1)
+        .threads(Some(1))
+        .limit(Some(10))
+        .fuzz_path(String::from("tests/fuzz_config.toml"))
+        .build();
+
+    tcp::clobber(config, b"foo".to_vec())?;
+
+    Ok(())
+}

--- a/tests/test_tcp_clobber.rs
+++ b/tests/test_tcp_clobber.rs
@@ -65,7 +65,7 @@ fn with_fuzz_config() -> std::io::Result<()> {
         .connections(1)
         .threads(Some(1))
         .limit(Some(10))
-        .fuzz_path(String::from("tests/fuzz_config.toml"))
+        .fuzz_path(Some(String::from("tests/fuzz_config.toml")))
         .build();
 
     tcp::clobber(config, b"foo".to_vec())?;

--- a/tests/test_tcp_clobber.rs
+++ b/tests/test_tcp_clobber.rs
@@ -6,7 +6,7 @@ use log::LevelFilter;
 use std::time::Duration;
 
 fn test_message() -> Message {
-    Message::new(b"GET / HTTP/1.1\r\nHost: localhost:8000\r\n\r\n".to_vec())
+    Message::new(b"GET / HTTP/1.1\r\nHost: localhost:8000\r\n\r\n")
 }
 
 #[allow(dead_code)]

--- a/tests/test_tcp_clobber.rs
+++ b/tests/test_tcp_clobber.rs
@@ -5,8 +5,8 @@ use clobber::*;
 use log::LevelFilter;
 use std::time::Duration;
 
-fn test_message() -> Message {
-    Message::new(b"GET / HTTP/1.1\r\nHost: localhost:8000\r\n\r\n")
+fn test_message() -> Vec<u8> {
+    b"GET / HTTP/1.1\r\nHost: localhost:8000\r\n\r\n".to_vec()
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
Added a new optional `--fuzz` parameter, which loads in a .toml file that defines how to mutate the input. Very early version of the feature. 